### PR TITLE
feat: Add `Functions` field to options.TerragruntOptions

### DIFF
--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -111,8 +111,9 @@ func CreateTerragruntEvalContext(
 	terragruntOptions *options.TerragruntOptions,
 	extensions EvalContextExtensions,
 ) (*hcl.EvalContext, error) {
+	baseDir := filepath.Dir(filename)
 	tfscope := tflang.Scope{
-		BaseDir: filepath.Dir(filename),
+		BaseDir: baseDir,
 	}
 
 	terragruntFunctions := map[string]function.Function{
@@ -159,6 +160,12 @@ func CreateTerragruntEvalContext(
 	}
 	for k, v := range terraformCompatibilityFunctions {
 		functions[k] = v
+	}
+
+	if terragruntOptions.Functions != nil {
+		for k, v := range terragruntOptions.Functions(baseDir) {
+			functions[k] = v
+		}
 	}
 
 	ctx := &hcl.EvalContext{

--- a/options/options.go
+++ b/options/options.go
@@ -8,10 +8,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/gruntwork-io/terragrunt/errors"
-	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
+	"github.com/zclconf/go-cty/cty/function"
+
+	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/util"
 )
 
 var TERRAFORM_COMMANDS_WITH_SUBCOMMAND = []string{
@@ -207,6 +209,15 @@ type TerragruntOptions struct {
 
 	// Controls if a module prefix will be prepended to TF outputs
 	IncludeModulePrefix bool
+
+	// Functions is an optional field which provides a way to add extra functions to the Terragrunt Evaluation Context.
+	// It specifies a function which will be called with the directory of the terragrunt.hcl which is being evaluated.
+	// It should return a map where keys are the names of Terragrunt functions, and values are the corresponding function
+	// implementations. These functions are incorporated into the hcl.EvalContext prior to evaluation.
+	// They always supersede the base functions from Terraform or Terragrunt. This means that the
+	// Functions field can be utilized to overwrite any base functions, which can be particularly
+	// beneficial for testing or cases where certain functions should not be executed.
+	Functions func(baseDir string) map[string]function.Function
 }
 
 // IAMOptions represents options that are used by Terragrunt to assume an IAM role.
@@ -387,6 +398,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		UsePartialParseConfigCache:     terragruntOptions.UsePartialParseConfigCache,
 		OutputPrefix:                   terragruntOptions.OutputPrefix,
 		IncludeModulePrefix:            terragruntOptions.IncludeModulePrefix,
+		Functions:                      terragruntOptions.Functions,
 	}
 }
 


### PR DESCRIPTION
This PR incorporates a `Functions` field into the `TerragruntOptions` struct. This addition permits Terragrunt library consumers to alter the `hcl.EvaluationContext` functions prior to file evaluation. It proves beneficial for two key use cases:

* Testing: Now, library developers can mock Terragrunt functions in their tests. This avoids sluggish tests and spotlights areas needing improvement in hcl parsing.
* Disable execution: With this new `Functions` feature, consumers can now deactivate function execution in specific contexts. This is essential for us at Infracost, as it allows us to bypass internal Terragrunt and Terraform functions that don't align with our use case and lead to unnecessary program exits. For instance, `get_terraform_cli_args`.
