### PR TITLE
refactor: use global cache for modules

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -480,7 +480,7 @@ func RunTerragrunt(terragruntOptions *options.TerragruntOptions) error {
 		return err
 	}
 	if sourceUrl != "" {
-		updatedTerragruntOptions, err = downloadTerraformSource(sourceUrl, terragruntOptions, terragruntConfig)
+		updatedTerragruntOptions, err = DownloadTerraformSource(sourceUrl, terragruntOptions, terragruntConfig)
 		if err != nil {
 			return err
 		}

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -24,6 +24,8 @@ const moduleInitRequiredFile = ".terragrunt-init-required"
 
 const tfLintConfig = ".tflint.hcl"
 
+// DownloadTerraformSource adds a Terraform source to the Terragrunt cache if necessary.
+//
 // 1. Download the given source URL, which should use Terraform's module source syntax, into a temporary folder
 // 2. Check if module directory exists in temporary folder
 // 3. Copy the contents of terragruntOptions.WorkingDir into the temporary folder.
@@ -31,7 +33,7 @@ const tfLintConfig = ".tflint.hcl"
 //
 // See the NewTerraformSource method for how we determine the temporary folder so we can reuse it across multiple
 // runs of Terragrunt to avoid downloading everything from scratch every time.
-func downloadTerraformSource(source string, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) (*options.TerragruntOptions, error) {
+func DownloadTerraformSource(source string, terragruntOptions *options.TerragruntOptions, terragruntConfig *config.TerragruntConfig) (*options.TerragruntOptions, error) {
 	terraformSource, err := tfsource.NewTerraformSource(source, terragruntOptions.DownloadDir, terragruntOptions.WorkingDir, terragruntOptions.Logger)
 	if err != nil {
 		return nil, err

--- a/cli/tfsource/types.go
+++ b/cli/tfsource/types.go
@@ -254,8 +254,6 @@ func encodeSourceName(sourceUrl *url.URL) (string, error) {
 		return "", errors.WithStackTrace(err)
 	}
 
-	sourceUrlNoQuery.RawQuery = ""
-
 	return util.EncodeBase64Sha1(sourceUrlNoQuery.String()), nil
 }
 

--- a/cli/tfsource/types.go
+++ b/cli/tfsource/types.go
@@ -103,7 +103,7 @@ func (terraformSource TerraformSource) WriteVersionFile() error {
 	return errors.WithStackTrace(ioutil.WriteFile(terraformSource.VersionFile, []byte(version), 0640))
 }
 
-// Take the given source path and create a TerraformSource struct from it, including the folder where the source should
+// NewTerraformSource takes the given source path and create a TerraformSource struct from it, including the folder where the source should
 // be downloaded to. Our goal is to reuse the download folder for the same source URL between Terragrunt runs.
 // Otherwise, for every Terragrunt command, you'd have to wait for Terragrunt to download your Terraform code, download
 // that code's dependencies (terraform get), and configure remote state (terraform remote config), which is very slow.
@@ -163,8 +163,7 @@ func NewTerraformSource(source string, downloadDir string, workingDir string, lo
 		return nil, err
 	}
 
-	encodedWorkingDir := util.EncodeBase64Sha1(canonicalWorkingDir)
-	updatedDownloadDir := util.JoinPath(downloadDir, encodedWorkingDir, rootPath)
+	updatedDownloadDir := util.JoinPath(downloadDir, rootPath)
 	updatedWorkingDir := util.JoinPath(updatedDownloadDir, modulePath)
 	versionFile := util.JoinPath(updatedDownloadDir, ".terragrunt-source-version")
 


### PR DESCRIPTION
This change refactors the Terragrunt cache logic so that module cache are shared across Terragrunt projects. This means that modules don't have to be re-downloaded/copied across projects. This change also exports the `DownloadTerraformSource` so that this logic can be consumed by 3rd parties.
