### PR TITLE
feat: add `GetOutputs` function to the `TerragruntOptions`

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gruntwork-io/go-commons/errors"
+
 	"github.com/gruntwork-io/terragrunt/aws_helper"
 	"github.com/gruntwork-io/terragrunt/codegen"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -425,6 +426,10 @@ func getTerragruntOutput(dependencyConfig Dependency, terragruntOptions *options
 	targetConfig := getCleanedTargetConfigPath(dependencyConfig.ConfigPath, terragruntOptions.TerragruntConfigPath)
 	if !util.FileExists(targetConfig) {
 		return nil, true, errors.WithStackTrace(DependencyConfigNotFound{Path: targetConfig})
+	}
+
+	if terragruntOptions.GetOutputs != nil {
+		return terragruntOptions.GetOutputs(targetConfig, terragruntOptions)
 	}
 
 	jsonBytes, err := getOutputJsonWithCaching(targetConfig, terragruntOptions)

--- a/options/options.go
+++ b/options/options.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
+	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 
 	"github.com/gruntwork-io/terragrunt/util"
@@ -257,6 +258,12 @@ type TerragruntOptions struct {
 
 	// Disalbes validation terraform command
 	DisableCommandValidation bool
+
+	// GetOutputs is a function that returns the outputs of a module. It is used to
+	// get the outputs of a module when executing the Terragrunt command is not
+	// possible. This is useful in environments where Terragrunt is not installed and
+	// outputs are orchestrated by a different method.
+	GetOutputs func(targetConfig string, ops *TerragruntOptions) (*cty.Value, bool, error)
 }
 
 // IAMOptions represents options that are used by Terragrunt to assume an IAM role.
@@ -455,6 +462,7 @@ func (opts *TerragruntOptions) Clone(terragruntConfigPath string) *TerragruntOpt
 		DisableBucketUpdate:            opts.DisableBucketUpdate,
 		TerraformImplementation:        opts.TerraformImplementation,
 		Functions:                      opts.Functions,
+		GetOutputs:                     opts.GetOutputs,
 	}
 }
 


### PR DESCRIPTION
Adds a new field `GetOutputs` to the options that is used when fetching outputs for a Terragrunt dependency. This solves a panic with our use of the library. This error occurs when a Terragrunt module dependency has a dependency defined in an include.

Normally, we handle all the dependency outputs before creating a new `EvalContext`. But when a dependency is defined in an include this is buried too deep in the library logic and thus eventually Terragrunt tries to collect the outputs by execing Terragrunt. We then hit a panic with "exec: no command" as Terragrunt is not installed in the run environment.

The `GetOutputs` approach means that if we do get to a point where the dependency hasn't already been provided as a higher level `tgconfig.EvalContextExtensions.DecodedDependency` from the `TerragruntHCLProvider` we then fallback to calling this function rather than trying to exec a binary.

*Note*: This method has the potential to completely replace our dependency output collecting method. Instead, relying soley on the `GetOutputs` function to be called when Terragrunt needs outputs. This could remove a lot of code from the `TerragruntHCLProvider` and be more maintainable. However, I haven't done this for now, as I think this is outside the scope of this change.
