### PR TITLE
External dependency loading improvements

### DIFF
--- a/config/cache.go
+++ b/config/cache.go
@@ -76,14 +76,14 @@ func (cache *IAMRoleOptionsCache) Put(key string, value options.IAMRoleOptions) 
 
 // TerragruntConfigCache - structure to store cached values
 type TerragruntConfigCache struct {
-	Cache map[string]TerragruntConfig
+	Cache map[string]*TerragruntConfig
 	Mutex *sync.Mutex
 }
 
 // NewTerragruntConfigCache - create new TerragruntConfig cache
 func NewTerragruntConfigCache() *TerragruntConfigCache {
 	return &TerragruntConfigCache{
-		Cache: map[string]TerragruntConfig{},
+		Cache: map[string]*TerragruntConfig{},
 		Mutex: &sync.Mutex{},
 	}
 }
@@ -91,7 +91,7 @@ func NewTerragruntConfigCache() *TerragruntConfigCache {
 // Get - get cached value
 // Design decision: Drop the sha256 because map is already a hashtable
 // See https://go.dev/src/runtime/map.go
-func (cache *TerragruntConfigCache) Get(key string) (TerragruntConfig, bool) {
+func (cache *TerragruntConfigCache) Get(key string) (*TerragruntConfig, bool) {
 	keyAsByte := []byte(key)
 	cacheKey := fmt.Sprintf("%x", keyAsByte)
 
@@ -102,7 +102,7 @@ func (cache *TerragruntConfigCache) Get(key string) (TerragruntConfig, bool) {
 }
 
 // Put - put value in cache
-func (cache *TerragruntConfigCache) Put(key string, value TerragruntConfig) {
+func (cache *TerragruntConfigCache) Put(key string, value *TerragruntConfig) {
 	keyAsByte := []byte(key)
 	cacheKey := fmt.Sprintf("%x", keyAsByte)
 

--- a/configstack/module.go
+++ b/configstack/module.go
@@ -380,7 +380,7 @@ func resolveExternalDependenciesForModules(moduleMap map[string]*TerraformModule
 	}
 
 	if len(allExternalDependencies) > 0 {
-		recursiveDependencies, err := resolveExternalDependenciesForModules(allExternalDependencies, moduleMap, recursionLevel+1, terragruntOptions, childTerragruntConfig)
+		recursiveDependencies, err := resolveExternalDependenciesForModules(allExternalDependencies, modulesToSkip, recursionLevel+1, terragruntOptions, childTerragruntConfig)
 		if err != nil {
 			return allExternalDependencies, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	github.com/hashicorp/terraform-svchost v0.0.1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 // indirect
 	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef // indirect
+	github.com/huandu/go-clone v1.7.2
 	github.com/jessevdk/go-flags v1.5.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jstemmer/go-junit-report v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -674,6 +674,10 @@ github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87/go.mod h1:CtWFDAQg
 github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef h1:A9HsByNhogrvm9cWb28sjiS3i7tcKCkflWFEkHfuAgM=
 github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/go-clone v1.7.2 h1:3+Aq0Ed8XK+zKkLjE2dfHg0XrpIfcohBE1K+c8Usxoo=
+github.com/huandu/go-clone v1.7.2/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=


### PR DESCRIPTION
This has 2 fixes:
1. Makes sure that modules that have already been resolved aren't resolved again. Previously, this wasn't passing all the previously resolved modules through the recursive calls which was causing the max recursion limit to be hit when it shouldn't have.
2. Previously when using the PartialConfig cache, the previous entries were modified after they'd been added to the cache. This was causing modules to inherit any dependencies if they were included in other modules, which in turn caused circular depedency issues. This ensures the cache is cloned when it is read using logic similar to https://github.com/gruntwork-io/terragrunt/pull/3307