### PR TITLE
fix: recover if decoding to cty type is not possible

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -306,7 +306,13 @@ func dependencyBlocksToCtyValue(dependencyConfigs []Dependency, terragruntOption
 			continue
 		}
 		dependencyConfig := dependencyConfig // https://golang.org/doc/faq#closures_and_goroutines
-		dependencyErrGroup.Go(func() error {
+		dependencyErrGroup.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = errors.WithStackTrace(fmt.Errorf("%v", r))
+				}
+			}()
+
 			// Loose struct to hold the attributes of the dependency. This includes:
 			// - outputs: The module outputs of the target config
 			dependencyEncodingMap := map[string]cty.Value{}


### PR DESCRIPTION
Resolves unhandled panic if the dependency outputs type cannot be decoded to a
valid cty type. I could not find the specific output that caused this panic,
however it is likely to do with unresolved data/mock outputs. Ultimately we
should just return an error here so that we can process the other projects in
the stack. Otherwise the unhandled panic kills the whole run.